### PR TITLE
docs(release): finalize v1.0.0-rc.1 notes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,10 @@
 # Security policy
 
-## Supported version
+## Supported versions
 
-No version has been released. The latest commit on `main` is the only supported
-private-development version until a tagged release is published.
+During the release-candidate period, the current `main` branch and the latest
+`v1.0.0-rc.x` GitHub prerelease receive security updates. Superseded release
+candidates are not supported.
 
 ## Reporting a vulnerability
 

--- a/docs/PUBLIC-READINESS-REPORT-2026-08-28.md
+++ b/docs/PUBLIC-READINESS-REPORT-2026-08-28.md
@@ -19,6 +19,33 @@ or supersedes the private remote.
 
 Readiness score: **96 out of 100**.
 
+## Publication update, 2026-08-31
+
+The owner approved publishing the clean replacement repository while keeping
+the archived private history private. The candidate was cloned again from
+GitHub, installed from its frozen lockfile, and passed the full CI command
+against a disposable loopback PostgreSQL service. The dependency audit again
+reported no known vulnerability.
+
+Owner-supervised live acceptance produced 11 completed live sessions, including
+nine full 19-source guided reports. The release estimator reported $0.495, and
+the most recent full saved run recorded $0.50256. A saved 19-source report
+containing 294 keyword rows reopened without another provider request. The
+release code generated a 294-row CSV, parseable JSON, and a valid seven-page PDF
+from that saved report.
+
+The final pre-public audit covered `main` and all five active Dependabot
+branches. Detect-secrets reported no unexpected finding. The only entropy
+findings were package-manager integrity values and the reviewed screenshot
+SHA-256 values. No tracked private-state path, local absolute path, embedded
+authenticated URL, private-key material, or unexpected commit identity was
+found.
+
+Public-only security controls, anonymous access verification, the immutable
+tag, and the GitHub prerelease remain part of the controlled visibility
+cutover. This update records new evidence without rewriting the original
+2026-08-28 assessment.
+
 | Area | Score | Evidence |
 | --- | ---: | --- |
 | Install, build, and runtime | 25/25 | Frozen install, two migrations, seed, CI, production build, and loopback smoke test pass. |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,8 +13,9 @@ not by itself authorize a tag, GitHub Release, license, or visibility change.
       by synthetic demo data.
 - [x] Build and verify a one-commit clean-history projection whose commit uses
       only the project-safe `.invalid` identity.
-- [ ] Obtain owner approval for the remote cutover strategy. Do not make the
-      existing private history public in place.
+- [x] Obtain owner approval for the remote cutover strategy. On 2026-08-31 the
+      owner approved publishing the clean replacement repository. The archived
+      private history remains private.
 - [x] Remove non-keyword provider and source-product execution code from the
       distributed source.
 - [x] Add a transactional, data-preserving migration from private-preview
@@ -26,8 +27,9 @@ not by itself authorize a tag, GitHub Release, license, or visibility change.
       or deletion action is required for the inspected local database.
 - [x] Complete clean-clone, production, and visible-browser acceptance on the
       release-candidate source tree.
-- [ ] Complete the owner-approved paid run, or record the owner's explicit
-      decision to release without that proof.
+- [x] Complete the owner-approved paid run, or record the owner's explicit
+      decision to release without that proof. Owner-supervised acceptance
+      completed nine full 19-source guided reports.
 
 Do not create an RC tag while any item above remains open.
 
@@ -92,8 +94,12 @@ release publication.
       and market-aware report-source counts.
 - [x] Check desktop and narrow layouts, select chevrons, chart resizing, empty
       states, community links, and the browser console in a visible browser.
-- [ ] With explicit spending approval, run one guided report and record the
+- [x] With explicit spending approval, run one guided report and record the
       displayed estimate, actual cost, source count, saved reopen, and exports.
+      The release estimator reported $0.495. Nine full runs completed with 19
+      sources, and the most recent full saved run recorded $0.50256. A saved
+      294-row report reopened without another provider request and generated a
+      294-row CSV, parseable JSON, and a valid seven-page PDF.
 
 ## Tag and prerelease
 

--- a/docs/releases/v1.0.0-rc.1.md
+++ b/docs/releases/v1.0.0-rc.1.md
@@ -18,6 +18,22 @@ local-first keyword research console.
 - Review eight real application screenshots generated from deterministic
   synthetic data with no account or provider-response data.
 
+## Install
+
+Requirements are Node.js 24, pnpm 9, OpenSSL, and Podman or Docker.
+
+```bash
+git clone https://github.com/AgriciDaniel/keywordpro.git
+cd keywordpro
+git checkout v1.0.0-rc.1
+cp .env.example .env
+pnpm install --frozen-lockfile --ignore-workspace
+```
+
+Generate a unique 32-byte encryption key, add it to `.env`, and follow the
+database startup and migration steps in the README. Do not copy credentials
+from another installation.
+
 ## Privacy and supported use
 
 Credentials stay on the local server, saved values are encrypted at rest, and
@@ -40,11 +56,28 @@ market, language, account access, and provider response.
   checks.
 - Fresh-install migration, repeat migration, local-user seed, legacy-data
   inventory, production startup, and loopback health checks passed.
+- Owner-supervised live acceptance completed nine full 19-source guided
+  reports. The release estimator reported $0.495, and the most recent full
+  saved run recorded $0.50256. Saved reports reopened without another provider
+  request.
+- A saved 19-source live report containing 294 keyword rows produced a
+  294-row CSV, parseable JSON, and a valid seven-page PDF.
+- A final pre-public scan covered `main` and all five active Dependabot
+  branches. Detect-secrets reported no unexpected finding. Its only findings
+  were package-manager integrity values and reviewed screenshot SHA-256 values.
 
 ## Release-candidate status
 
 This is a prerelease for installation and local evaluation. Report issues in
 the repository before the final `v1.0.0` release.
+
+Known limits:
+
+- Keyword Pro supports one local user and binds to loopback by default.
+- Live DataForSEO calls spend money and can return different coverage by
+  market, language, and account access.
+- Direct LAN or internet exposure is unsupported without authentication and a
+  deployment-specific security review.
 
 See the repository README for installation, screenshots, limits, and security
 guidance. Licensed under Apache-2.0.


### PR DESCRIPTION
## Summary

Finalizes the evidence-based release notes and release gates for Keyword Pro
v1.0.0-rc.1. It records the owner-approved clean-repository cutover, completed
live DataForSEO acceptance, and saved-report export verification before the
repository becomes public.

## Changes

- Add installation and known-limit guidance to the RC release notes.
- Record nine complete 19-source live runs and their measured cost evidence.
- Record CSV, JSON, and PDF verification from a saved 294-row live report.
- Update the release checklist and prerelease security-support policy.
- Preserve the original dated readiness score while appending new evidence.

## Verification

- `pnpm install --frozen-lockfile --ignore-workspace`: passed on the clean clone.
- `pnpm --ignore-workspace run ci`: passed against disposable PostgreSQL with
  675 offline assertions, Biome checking 184 files, TypeScript, database and
  legacy-data checks, and the Next.js production build.
- The first local CI attempt had no `DATABASE_URL` and stopped at the database
  migration verifier. The complete rerun used an isolated loopback PostgreSQL
  service and passed.
- `pnpm --ignore-workspace audit --audit-level low`: no known vulnerabilities.
- `pnpm --ignore-workspace verify:repository-safety`: 6 passed, 0 failed.
- Detect-secrets scanned every tracked file: 0 unexpected findings. Reported
  entropy is limited to pnpm integrity values and reviewed screenshot hashes.
- All six reachable GitHub refs were separately scanned before this branch:
  0 unexpected secret findings, private-state paths, local absolute paths,
  authenticated URLs, or private-key markers.
- Saved live export check: 294 CSV data rows, parseable JSON, and a valid
  seven-page PDF.

## Risk and rollback

Low risk, documentation only. Revert the merge if any recorded evidence is
found inaccurate. Repository visibility, tags, and releases are unchanged by
this pull request.

## Open items

- Make the clean replacement repository public after this merge.
- Enable secret scanning, push protection, private vulnerability reporting,
  and CodeQL, then require the successful CodeQL result.
- Verify anonymous clone, README, license, security reporting, and source
  archives.
- Create the immutable `v1.0.0-rc.1` tag and publish the reviewed prerelease.
- Five Dependabot update pull requests remain separate and deliberately
  unmerged, including major-version updates that need their own review.
