### PR TITLE
fix(security): sanitize endpoint group ids globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ No changes yet.
 
 - Non-keyword API requests are rejected before credentials or providers are
   reached.
+- Generated endpoint-group IDs replace every separator in one global
+  sanitization step and are verified against a safe-character invariant.
 - Startup rejects conflicting canonical and legacy encryption settings instead
   of silently choosing one.
 - Encryption keys can be read from a private file without copying the secret

--- a/docs/PUBLIC-READINESS-REPORT-2026-08-28.md
+++ b/docs/PUBLIC-READINESS-REPORT-2026-08-28.md
@@ -46,6 +46,11 @@ tag, and the GitHub prerelease remain part of the controlled visibility
 cutover. This update records new evidence without rewriting the original
 2026-08-28 assessment.
 
+The first public CodeQL run identified incomplete sanitization in generated
+endpoint-group IDs. The release candidate now replaces all separators in one
+global operation and verifies every generated ID against a safe-character
+invariant. The expanded offline suite contains 677 assertions.
+
 | Area | Score | Evidence |
 | --- | ---: | --- |
 | Install, build, and runtime | 25/25 | Frozen install, two migrations, seed, CI, production build, and loopback smoke test pass. |

--- a/docs/releases/v1.0.0-rc.1.md
+++ b/docs/releases/v1.0.0-rc.1.md
@@ -46,7 +46,7 @@ market, language, account access, and provider response.
 
 ## Verification
 
-- 675 offline assertions passed.
+- 677 offline assertions passed.
 - Biome checked 184 files, TypeScript passed, and the production build passed.
 - The dependency audit found 0 known vulnerabilities.
 - Six repository-safety checks found no tracked secrets, personal email
@@ -65,6 +65,8 @@ market, language, account access, and provider response.
 - A final pre-public scan covered `main` and all five active Dependabot
   branches. Detect-secrets reported no unexpected finding. Its only findings
   were package-manager integrity values and reviewed screenshot SHA-256 values.
+- Generated endpoint-group IDs replace every separator in one global
+  sanitization step and pass a safe-character invariant.
 
 ## Release-candidate status
 

--- a/scripts/verify-keyword-pro.ts
+++ b/scripts/verify-keyword-pro.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { computeDatabaseSsl } from '../src/db';
-import { RESEARCH_ENDPOINT_CATALOG } from '../src/lib/research/endpoint-catalog';
+import {
+  ENDPOINT_SUBCATEGORIES,
+  RESEARCH_ENDPOINT_CATALOG,
+} from '../src/lib/research/endpoint-catalog';
 import { ENDPOINT_METADATA } from '../src/lib/research/endpoint-metadata';
 import { ENDPOINT_TARGETING_FIELDS } from '../src/lib/research/endpoint-targeting.generated';
 import { ENDPOINTS } from '../src/lib/research/endpoints';
@@ -66,6 +69,16 @@ check(
     (endpoint) => endpoint.mode === 'keyword' && endpoint.provider === 'dataforseo',
   ),
   'UI catalog contains a non-keyword mode or provider',
+);
+
+const subcategoryIds = ENDPOINT_SUBCATEGORIES.map((subcategory) => subcategory.id);
+check(
+  new Set(subcategoryIds).size === subcategoryIds.length,
+  'Endpoint subcategory IDs contain duplicates',
+);
+check(
+  subcategoryIds.every((id) => /^[a-z0-9_-]+$/.test(id)),
+  'Endpoint subcategory IDs contain unsafe separator characters',
 );
 
 const targetingTypes = Object.keys(ENDPOINT_TARGETING_FIELDS);

--- a/src/lib/research/endpoint-catalog.ts
+++ b/src/lib/research/endpoint-catalog.ts
@@ -425,7 +425,7 @@ function deriveSubcategories(): EndpointSubcategory[] {
     const segments = key.slice(key.indexOf('|') + 1).split('.');
     const label = segments.slice(1).map(humanise).join(' ') || humanise(segments[0]);
     return {
-      id: `auto-${key.replace('|', '-').replace(/\./g, '-')}`,
+      id: `auto-${key.replace(/[|.]/g, '-')}`,
       label: label === 'More' ? `More ${humanise(segments[0])}` : label,
       mode: members[0].mode as EndpointConsoleMode,
       description: `${members.length} ${humanise(segments[0])} endpoints.`,


### PR DESCRIPTION
## Summary

Closes the high-severity CodeQL incomplete-sanitization finding before the
first public prerelease. Generated endpoint-group IDs now normalize every pipe
or period in one global replacement and are covered by explicit safe-character
and uniqueness invariants.

## Changes

- Replace chained partial separator replacement with one global replacement.
- Verify all endpoint subcategory IDs are unique and contain safe characters.
- Record the CodeQL finding and corrected 677-assertion release evidence.
- Document the fix in the v1.0.0-rc.1 changelog and release notes.

## Verification

- `pnpm --ignore-workspace run ci`: passed against disposable PostgreSQL with
  677 offline assertions, Biome checking 184 files, TypeScript, database and
  legacy-data checks, and the Next.js production build.
- `pnpm --ignore-workspace verify:keyword-pro`: 376 checks passed and all 332
  keyword endpoints remained admitted.
- `pnpm --ignore-workspace audit --audit-level low`: no known vulnerabilities.
- `pnpm --ignore-workspace verify:repository-safety`: 6 passed, 0 failed.
- Detect-secrets scanned every tracked file: 0 unexpected findings.
- `git diff --check`: passed.

## Risk and rollback

Low risk. Current generated IDs are unchanged, so saved UI selection values and
endpoint routing remain compatible. Revert the merge if CodeQL does not close
or any generated-ID behavior changes.

## Open items

- Rerun CodeQL on the merged `main` commit and confirm zero open alerts.
- Add the successful CodeQL context to protected `main`.
- Keep the immutable tag and prerelease unpublished until those checks pass.
